### PR TITLE
async: Add async source wrapper to utilise a handler pattern.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Collection of middleware, wrappers and other tools for substrate.
 Is a message source wrapper that allows the user to acknowledge messages in any order and it will ensure
 messages are sent to the actual message source in the same order they are consumed.
 
+### Async
+Is an async message source wrapper that allows the user to utilise a handler pattern for interacting
+with an async message source. It removes the need to manually handle the message and acknowledgement
+channels.
+
 ### Instrumented
 Provides wrappers for both message source and message sink that add prometheus metrics labeled with topic and status (either success or error).
 

--- a/async/source.go
+++ b/async/source.go
@@ -1,0 +1,90 @@
+package async
+
+import (
+	"context"
+
+	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/sync/rungroup"
+)
+
+// AckFunc is a function to call to send acknowledgement that a message was received. It should be
+// called at least once for each message read.
+type AckFunc func() error
+
+// ConsumerMessageHandler is the callback function type that async message consumers must implement.
+// The AckFunc should be called at least once for each message read. Multiple calls of the AckFunc
+// will do nothing.
+type ConsumerMessageHandler func(ctx context.Context, msg substrate.Message, ack AckFunc) error
+
+// MessageSource represents a message source that allows async consumption and relieves the consumer
+// from having to deal with acknowledgements using channels.
+type MessageSource interface {
+	// Close closed the MessageSource, freeing underlying resources.
+	Close() error
+	// ConsumeMessages calls the handler function for each message available to consume. An
+	// acknowledgement will only be sent to the broker when the handler calls the AckFunc provided.
+	// If an error is returned by the handler, it will be propogated and returned from this
+	// function. This function will block until the context is done or until an error occurs.
+	ConsumeMessages(ctx context.Context, handler ConsumerMessageHandler) error
+	substrate.Statuser
+}
+
+// NewMessageSource returns a new insurance asynchronous message source, given
+// an AsyncMessageSource. When Close is called on the AsyncMessageSource,
+// this is also propogated to the underlying AsyncMessageSource.
+func NewMessageSource(ams substrate.AsyncMessageSource) MessageSource {
+	return &messageSourceAdapter{
+		ams,
+	}
+}
+
+type messageSourceAdapter struct {
+	ac substrate.AsyncMessageSource
+}
+
+func (a *messageSourceAdapter) ConsumeMessages(ctx context.Context, handler ConsumerMessageHandler) error {
+	rg, ctx := rungroup.New(ctx)
+
+	messages := make(chan substrate.Message)
+	acks := make(chan substrate.Message)
+
+	rg.Go(func() error {
+		return a.ac.ConsumeMessages(ctx, messages, acks)
+	})
+
+	rg.Go(func() error {
+		for {
+			select {
+			case msg := <-messages:
+				acked := false
+				ackFunc := func() error {
+					if acked {
+						return nil
+					}
+					select {
+					case acks <- msg:
+						acked = true
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+				if err := handler(ctx, msg, ackFunc); err != nil {
+					return err
+				}
+			case <-ctx.Done():
+				return nil
+			}
+		}
+	})
+
+	return rg.Wait()
+}
+
+func (a *messageSourceAdapter) Close() error {
+	return a.ac.Close()
+}
+
+func (a *messageSourceAdapter) Status() (*substrate.Status, error) {
+	return a.ac.Status()
+}

--- a/async/source_test.go
+++ b/async/source_test.go
@@ -1,0 +1,230 @@
+package async
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/substrate-tools/message"
+)
+
+type messageSourceMock struct {
+	substrate.AsyncMessageSource
+	consumerMessagesMock func(context.Context, chan<- substrate.Message, <-chan substrate.Message) error
+}
+
+func (m messageSourceMock) ConsumeMessages(ctx context.Context, in chan<- substrate.Message, acks <-chan substrate.Message) error {
+	return m.consumerMessagesMock(ctx, in, acks)
+}
+
+func TestConsumeMessagesSuccessfully(t *testing.T) {
+	receivedAcks := make(chan substrate.Message)
+
+	source := messageSourceAdapter{
+		ac: &messageSourceMock{
+			consumerMessagesMock: func(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
+				messages <- message.FromString("payload")
+
+				for {
+					select {
+					case <-ctx.Done():
+						return nil
+					case ack := <-acks:
+						receivedAcks <- ack
+					}
+				}
+			},
+		},
+	}
+
+	sourceContext, sourceCancel := context.WithTimeout(context.Background(), time.Second)
+	defer sourceCancel()
+
+	errs := make(chan error)
+
+	go func() {
+		defer close(errs)
+		errs <- source.ConsumeMessages(sourceContext, func(_ context.Context, _ substrate.Message, ack AckFunc) error {
+			return ack()
+		})
+	}()
+
+	for {
+		select {
+		case err := <-errs:
+			assert.NoError(t, err)
+			return
+		case ack := <-receivedAcks:
+			assert.NotEmpty(t, ack.Data())
+
+			sourceCancel()
+		}
+	}
+}
+
+func TestConsumeMessagesDoubleAckFuncCall(t *testing.T) {
+	receivedAcks := make(chan substrate.Message)
+
+	source := messageSourceAdapter{
+		ac: &messageSourceMock{
+			consumerMessagesMock: func(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
+				messages <- message.FromString("payload")
+
+				for {
+					select {
+					case <-ctx.Done():
+						return nil
+					case ack := <-acks:
+						receivedAcks <- ack
+					}
+				}
+			},
+		},
+	}
+
+	sourceContext, sourceCancel := context.WithTimeout(context.Background(), time.Second)
+	defer sourceCancel()
+
+	errs := make(chan error)
+
+	go func() {
+		defer close(errs)
+		errs <- source.ConsumeMessages(sourceContext, func(_ context.Context, _ substrate.Message, ack AckFunc) error {
+			defer sourceCancel()
+			err := ack()
+			if err != nil {
+				return err
+			}
+			return ack()
+		})
+	}()
+	ackCount := 0
+	for {
+		select {
+		case err := <-errs:
+			assert.NoError(t, err)
+			return
+		case ack := <-receivedAcks:
+			ackCount++
+			if ackCount == 1 {
+				assert.NotEmpty(t, ack.Data())
+			} else {
+				assert.FailNow(t, "received unexpected ack")
+			}
+		}
+	}
+}
+
+func TestConsumeMessagesAckFuncTimeout(t *testing.T) {
+	receivedAcks := make(chan substrate.Message)
+
+	source := messageSourceAdapter{
+		ac: &messageSourceMock{
+			consumerMessagesMock: func(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
+				messages <- message.FromString("payload")
+
+				select {
+				case <-ctx.Done():
+					return nil
+				default:
+					return nil
+				}
+			},
+		},
+	}
+
+	sourceContext, sourceCancel := context.WithTimeout(context.Background(), time.Second)
+	defer sourceCancel()
+
+	errs := make(chan error)
+
+	go func() {
+		defer close(errs)
+		errs <- source.ConsumeMessages(sourceContext, func(_ context.Context, _ substrate.Message, ack AckFunc) error {
+			return ack()
+		})
+	}()
+
+	for {
+		select {
+		case err := <-errs:
+			assert.Error(t, err)
+			return
+		case <-receivedAcks:
+			require.FailNow(t, "should not ack")
+		}
+	}
+}
+
+func TestConsumeMessagesWithError(t *testing.T) {
+	consumingErr := errors.New("consuming error")
+
+	source := messageSourceAdapter{
+		ac: &messageSourceMock{
+			consumerMessagesMock: func(_ context.Context, _ chan<- substrate.Message, _ <-chan substrate.Message) error {
+				return consumingErr
+			},
+		},
+	}
+
+	sourceContext, sourceCancel := context.WithCancel(context.Background())
+	defer sourceCancel()
+
+	errs := make(chan error)
+	go func() {
+		defer close(errs)
+		errs <- source.ConsumeMessages(sourceContext, func(_ context.Context, _ substrate.Message, ack AckFunc) error {
+			return ack()
+		})
+	}()
+
+	err := <-errs
+	assert.Error(t, err)
+	assert.Equal(t, consumingErr, err)
+
+	sourceCancel()
+}
+
+func TestConsumeOnBackendShutdown(t *testing.T) {
+	expectedErr := errors.New("shutdown")
+	backendCtx, backendCancel := context.WithCancel(context.Background())
+
+	source := messageSourceAdapter{
+		ac: &messageSourceMock{
+			consumerMessagesMock: func(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-backendCtx.Done():
+					return expectedErr
+				}
+			},
+		},
+	}
+
+	sourceContext, sourceCancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer sourceCancel()
+
+	errs := make(chan error)
+	go func() {
+		defer close(errs)
+		errs <- source.ConsumeMessages(sourceContext, func(_ context.Context, _ substrate.Message, ack AckFunc) error {
+			return ack()
+		})
+	}()
+
+	// Shutdown backend
+	backendCancel()
+
+	// Check wrapper shuts down properly
+	select {
+	case <-sourceContext.Done():
+		t.Fatalf("Wrapper failed to shutdown.")
+	case err := <-errs:
+		assert.Equal(t, expectedErr, err)
+	}
+}


### PR DESCRIPTION
Wrap the substrate async consumer to remove the need for the user of the
interface to handle the message and ack channels manually.

Closely resembles and inspired by the substrate sync adapter wrappers.