### PR TITLE
Instrumented async message sink: do not increment error counter if the context was cancelled.

### DIFF
--- a/instrumented/sink.go
+++ b/instrumented/sink.go
@@ -2,6 +2,7 @@ package instrumented
 
 import (
 	"context"
+	"errors"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/uw-labs/substrate"
@@ -58,7 +59,7 @@ func (ams *instrumentedSink) PublishMessages(ctx context.Context, acks chan<- su
 			case <-ctx.Done():
 				return <-errs
 			case err := <-errs:
-				if err != nil {
+				if isUnexpectedError(err) {
 					ams.counter.WithLabelValues("error", ams.topic).Inc()
 				}
 				return err
@@ -66,11 +67,23 @@ func (ams *instrumentedSink) PublishMessages(ctx context.Context, acks chan<- su
 		case <-ctx.Done():
 			return <-errs
 		case err := <-errs:
-			if err != nil {
+			if isUnexpectedError(err) {
 				ams.counter.WithLabelValues("error", ams.topic).Inc()
 			}
 			return err
 		}
+	}
+}
+
+func isUnexpectedError(err error) bool {
+	switch {
+	case err == nil:
+		return false
+	case errors.Is(err, context.Canceled):
+		// we're expecting producers to mark the stopping of producing by cancelling the context
+		return false
+	default:
+		return true
 	}
 }
 

--- a/instrumented/sink_test.go
+++ b/instrumented/sink_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uw-labs/substrate"
 )
 
@@ -69,6 +70,60 @@ func TestPublishMessagesSuccessfully(t *testing.T) {
 		select {
 		case err := <-errs:
 			assert.NoError(t, err)
+			return
+		case <-acks:
+			var metric dto.Metric
+			assert.NoError(t, sink.counter.WithLabelValues("success", "testTopic").Write(&metric))
+			assert.Equal(t, 1, int(*metric.Counter.Value))
+			sinkCancel()
+		}
+	}
+}
+
+func TestPublishMessagesSuccessfully_WithContextError(t *testing.T) {
+	sink := instrumentedSink{
+		impl: &asyncMessageSinkMock{
+			publishMessageMock: func(ctx context.Context, acks chan<- substrate.Message, messages <-chan substrate.Message) error {
+				for {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case msg := <-messages:
+						acks <- msg
+					}
+				}
+			},
+		},
+		counter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Help: "sink_counter",
+				Name: "sink_counter",
+			}, []string{"status", "topic"}),
+		topic: "testTopic",
+	}
+
+	acks := make(chan substrate.Message)
+	messages := make(chan substrate.Message)
+
+	sinkContext, sinkCancel := context.WithCancel(context.Background())
+	defer sinkCancel()
+
+	errs := make(chan error)
+	go func() {
+		defer close(errs)
+		errs <- sink.PublishMessages(sinkContext, acks, messages)
+	}()
+
+	messages <- Message{}
+
+	for {
+		select {
+		case err := <-errs:
+			assert.True(t, errors.Is(err, context.Canceled))
+			// the error counter should not be increased when producing stops by context canceling
+			var metric dto.Metric
+			assert.NoError(t, sink.counter.WithLabelValues("error", "testTopic").Write(&metric))
+			assert.Equal(t, 0, int(*metric.Counter.Value))
 			return
 		case <-acks:
 			var metric dto.Metric


### PR DESCRIPTION
Replica of https://github.com/uw-labs/substrate/pull/133