### PR TITLE
async: message ordering guarantee doc

### DIFF
--- a/async/source.go
+++ b/async/source.go
@@ -26,8 +26,8 @@ func WithSourceAckBufferSize(size uint) MessageSourceOption {
 
 // WithSourceConsumers sets the number of concurrent source consumers. The default value is 1 (synchronous).
 // Warning: When using Kafka (and possibly other backends), setting consumers > 1 breaks ordering guarantees
-// made possible by producing ordered to a topic using a KeyFunc. If this is something you care about, it's
-// reccomended that you set this value to 1 and scale horizontally.
+// made possible by producing ordered events to a topic using a KeyFunc. If this is something you care about,
+// it's reccomended that you set this value to 1 and scale horizontally.
 func WithSourceConsumers(consumers uint) MessageSourceOption {
 	return func(msa *messageSourceAdapter) {
 		msa.consumers = consumers

--- a/async/source.go
+++ b/async/source.go
@@ -25,6 +25,9 @@ func WithSourceAckBufferSize(size uint) MessageSourceOption {
 }
 
 // WithSourceConsumers sets the number of concurrent source consumers. The default value is 1 (synchronous).
+// Warning: When using Kafka (and possibly other backends), setting consumers > 1 breaks ordering guarantees
+// made possible by producing ordered to a topic using a KeyFunc. If this is something you care about, it's
+// reccomended that you set this value to 1 and scale horizontally.
 func WithSourceConsumers(consumers uint) MessageSourceOption {
 	return func(msa *messageSourceAdapter) {
 		msa.consumers = consumers

--- a/flush/sink_test.go
+++ b/flush/sink_test.go
@@ -58,7 +58,7 @@ func TestAsyncMessageSinkSuccess(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			sink.PublishMessage(ctx, []byte(string('A'+i)))
+			sink.PublishMessage(ctx, []byte(string(rune('A'+i))))
 		}(i)
 	}
 
@@ -113,7 +113,7 @@ func TestAsyncMessageSinkInterruption(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			sink.PublishMessage(ctx, []byte(string('A'+i)))
+			sink.PublishMessage(ctx, []byte(string(rune('A'+i))))
 		}(i)
 	}
 
@@ -286,7 +286,7 @@ func benchmarkBufferSizes(b *testing.B, msgBufferSize, ackBufferSize int) {
 		go func(i int) {
 			defer wg.Done()
 
-			sink.PublishMessage(ctx, []byte(string('A'+i)))
+			sink.PublishMessage(ctx, []byte(string(rune('A'+i))))
 		}(i)
 	}
 


### PR DESCRIPTION
This change also includes an update to flush/sink_test.go to support https://github.com/golang/go/issues/32479