### PR TITLE
Add batch message source.

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -1,0 +1,149 @@
+package batch
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/sync/rungroup"
+
+	"github.com/uw-labs/substrate-tools/batch/internal/ticker"
+)
+
+// Default configuration for the batch message source.
+const (
+	DefaultBatchSize    = 100
+	DefaultBatchMaxWait = 10 * time.Second
+)
+
+// ConsumerMessageHandler represents a consumer that processes messages un batches.
+type ConsumerMessageHandler func(ctx context.Context, batch []substrate.Message) error
+
+// MessageSource is a wrapper for substrate.AsyncMessageSource that hides the channel
+// usage and instead allows the user to consume messages in batches.
+type MessageSource interface {
+	ConsumeMessages(ctx context.Context, handler ConsumerMessageHandler) error
+	io.Closer
+	substrate.Statuser
+}
+
+// The MessageSourceOption type defines a function that modifies a field of the
+// batchMessageSource type
+type MessageSourceOption func(r *batchMessageSource)
+
+// WithBatchSize specifies batch size. The default is 100.
+func WithBatchSize(batchSize int) MessageSourceOption {
+	return func(r *batchMessageSource) {
+		r.batchSize = batchSize
+	}
+}
+
+// WithBatchMaxWait specifies the longest time the source should wait until it gets a full batch.
+// After this time passes an incomplete batch will be passed to the callback. The default is 10s.
+func WithBatchMaxWait(batchMaxWait time.Duration) MessageSourceOption {
+	return func(r *batchMessageSource) {
+		r.batchMaxWait = batchMaxWait
+	}
+}
+
+type batchMessageSource struct {
+	source substrate.AsyncMessageSource
+
+	batchMaxWait time.Duration
+	batchSize    int
+}
+
+// NewMessageSource returns a batch message source,
+func NewMessageSource(source substrate.AsyncMessageSource, opts ...MessageSourceOption) MessageSource {
+	s := &batchMessageSource{
+		source: source,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.batchMaxWait == time.Duration(0) {
+		s.batchMaxWait = DefaultBatchMaxWait
+	}
+	if s.batchSize == 0 {
+		s.batchSize = DefaultBatchSize
+	}
+	return s
+}
+
+// ConsumeMessages consumes messages in a batch.
+func (r *batchMessageSource) ConsumeMessages(ctx context.Context, handler ConsumerMessageHandler) error {
+	rg, ctx := rungroup.New(ctx)
+
+	acks := make(chan substrate.Message)
+	messages := make(chan substrate.Message)
+
+	rg.Go(func() error {
+		return r.handleMessages(ctx, handler, messages, acks)
+	})
+	rg.Go(func() error {
+		return r.source.ConsumeMessages(ctx, messages, acks)
+	})
+	return rg.Wait()
+}
+
+func (r *batchMessageSource) handleMessages(ctx context.Context, handler ConsumerMessageHandler, messages <-chan substrate.Message, acks chan<- substrate.Message) error {
+	tick := ticker.New(r.batchMaxWait)
+	defer tick.Stop()
+
+	batch := make([]substrate.Message, 0, r.batchSize)
+
+	process := func() error {
+		if len(batch) > 0 {
+			if err := handler(ctx, batch); err != nil {
+				return err
+			}
+		}
+
+		for _, ack := range batch {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case acks <- ack:
+			}
+		}
+
+		batch = make([]substrate.Message, 0, r.batchSize)
+		tick.Reset() // Reset the ticker to get correct deadline to receive next batch
+
+		return nil
+	}
+	putMessage := func(msg substrate.Message) error {
+		batch = append(batch, msg)
+
+		if len(batch) == r.batchSize {
+			return process()
+		}
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg := <-messages:
+			if err := putMessage(msg); err != nil {
+				return err
+			}
+		case <-tick.C:
+			if err := process(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// Status calls the status method on the underlying substrate.AsyncMessageSource
+func (r *batchMessageSource) Status() (*substrate.Status, error) {
+	return r.source.Status()
+}
+
+// Close closes the underlying substrate.AsyncMessageSource.
+func (r *batchMessageSource) Close() error {
+	return r.source.Close()
+}

--- a/batch/batch.go
+++ b/batch/batch.go
@@ -32,16 +32,16 @@ type MessageSource interface {
 // batchMessageSource type
 type MessageSourceOption func(r *batchMessageSource)
 
-// WithBatchSize specifies batch size. The default is 100.
-func WithBatchSize(batchSize int) MessageSourceOption {
+// WithSize specifies batch size. The default is 100.
+func WithSize(batchSize int) MessageSourceOption {
 	return func(r *batchMessageSource) {
 		r.batchSize = batchSize
 	}
 }
 
-// WithBatchMaxWait specifies the longest time the source should wait until it gets a full batch.
+// WithMaxWait specifies the longest time the source should wait until it gets a full batch.
 // After this time passes an incomplete batch will be passed to the callback. The default is 10s.
-func WithBatchMaxWait(batchMaxWait time.Duration) MessageSourceOption {
+func WithMaxWait(batchMaxWait time.Duration) MessageSourceOption {
 	return func(r *batchMessageSource) {
 		r.batchMaxWait = batchMaxWait
 	}

--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -1,0 +1,86 @@
+package batch_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uw-labs/substrate"
+
+	"github.com/uw-labs/substrate-tools/batch"
+	"github.com/uw-labs/substrate-tools/message"
+	"github.com/uw-labs/substrate-tools/mock"
+)
+
+func TestBatchMessageSource(t *testing.T) {
+	t.Parallel()
+	tt := []struct {
+		Name         string
+		Messages     []substrate.Message
+		BatchSize    int
+		HandlerError error
+
+		ExpectedBatches [][]substrate.Message
+		ExpectsError    bool
+	}{
+		{
+			Name: "It should process messages in batches",
+			Messages: []substrate.Message{
+				message.FromString("message-1"),
+				message.FromString("message-2"),
+				message.FromString("message-3"),
+				message.FromString("message-4"),
+			},
+			BatchSize: 2,
+			ExpectedBatches: [][]substrate.Message{{
+				message.FromString("message-1"),
+				message.FromString("message-2"),
+			}, {
+				message.FromString("message-3"),
+				message.FromString("message-4"),
+			}},
+		},
+		{
+			Name: "It should return errors from handler",
+			Messages: []substrate.Message{
+				message.FromString("handler-error"),
+			},
+			BatchSize: 1,
+			ExpectedBatches: [][]substrate.Message{{
+				message.FromString("handler-error"),
+			}},
+			ExpectsError: true,
+			HandlerError: fmt.Errorf("handler-error"),
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			source := batch.NewMessageSource(
+				&mock.AsyncMessageSource{Messages: tc.Messages},
+				batch.WithBatchSize(tc.BatchSize),
+				batch.WithBatchMaxWait(time.Second),
+			)
+
+			// Current issue with this test is it cancels the context after 3 seconds
+			// since rd.ConsumeMessages will go on forever. We get around this being a problem
+			// by running subtests in parallel, so overall test time is capped to 3 seconds.
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+			defer cancel()
+
+			batchCount := 0
+			expectedErr := tc.HandlerError
+			if expectedErr == nil {
+				expectedErr = context.DeadlineExceeded
+			}
+			assert.Equal(t, expectedErr, source.ConsumeMessages(ctx, func(ctx context.Context, messages []substrate.Message) error {
+				assert.Equal(t, tc.ExpectedBatches[batchCount], messages)
+				batchCount++
+				return tc.HandlerError
+			}))
+		})
+	}
+}

--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -61,8 +61,8 @@ func TestBatchMessageSource(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			source := batch.NewMessageSource(
 				&mock.AsyncMessageSource{Messages: tc.Messages},
-				batch.WithBatchSize(tc.BatchSize),
-				batch.WithBatchMaxWait(time.Second),
+				batch.WithSize(tc.BatchSize),
+				batch.WithMaxWait(time.Second),
 			)
 
 			// Current issue with this test is it cancels the context after 3 seconds

--- a/batch/internal/ticker/ticker.go
+++ b/batch/internal/ticker/ticker.go
@@ -1,0 +1,75 @@
+package ticker
+
+import (
+	"sync"
+	"time"
+)
+
+// ResetableTicker is a ticker implementation that can be reset.
+type ResetableTicker struct {
+	duration time.Duration
+	timer    *time.Timer
+	C        <-chan time.Time
+	reset    chan struct{}
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// New returns a new instance of a resetable ticker
+func New(d time.Duration) *ResetableTicker {
+	c := make(chan time.Time)
+
+	t := &ResetableTicker{
+		duration: d,
+		timer:    time.NewTimer(d),
+		C:        c,
+		reset:    make(chan struct{}),
+		stop:     make(chan struct{}),
+	}
+	go t.loop(c)
+
+	return t
+}
+
+// stopTimer stops the underlying timer and drains its channel if necessary.
+func (t *ResetableTicker) stopTimer() {
+	if !t.timer.Stop() {
+		<-t.timer.C
+	}
+}
+
+func (t *ResetableTicker) loop(out chan<- time.Time) {
+	for {
+		select {
+		case res := <-t.timer.C:
+			// Channel has been drained in this branch,
+			// so we don't have to worry about stopping the timer
+			select {
+			case out <- res:
+			case <-t.reset:
+			case <-t.stop:
+				return
+			}
+		case <-t.reset:
+			t.stopTimer()
+		case <-t.stop:
+			t.stopTimer()
+			return
+		}
+		t.timer.Reset(t.duration)
+	}
+}
+
+// Reset will restart the timer. It panics when called after reset.
+func (t *ResetableTicker) Reset() {
+	select {
+	case t.reset <- struct{}{}:
+	case <-t.stop:
+		panic("reset called after stop")
+	}
+}
+
+// Stop will stop the ticker.
+func (t *ResetableTicker) Stop() {
+	t.stopOnce.Do(func() { close(t.stop) })
+}

--- a/batch/internal/ticker/ticker_test.go
+++ b/batch/internal/ticker/ticker_test.go
@@ -1,0 +1,43 @@
+package ticker_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/uw-labs/substrate-tools/batch/internal/ticker"
+)
+
+const duration = time.Millisecond * 50
+
+func TestTicker(t *testing.T) {
+	assert := require.New(t)
+
+	prev := time.Now()
+	tick := ticker.New(duration)
+	defer tick.Stop()
+
+	for i := 0; i < 10; i++ {
+		cur := <-tick.C
+		actual := cur.Sub(prev)
+		prev = cur
+
+		assert.Truef(actual >= duration, "time gap too short: %v expected:%v", actual, duration)
+	}
+}
+
+func TestTicker_Reset(t *testing.T) {
+	assert := require.New(t)
+
+	tick := ticker.New(duration)
+	defer tick.Stop()
+
+	start := <-tick.C
+	time.Sleep(duration * 2)
+	tick.Reset()
+	end := <-tick.C
+
+	actual, expected := end.Sub(start), 3*duration
+	assert.Truef(actual >= 3*duration, "reset failed: time gap too short: %v expected:%v", actual, expected)
+}

--- a/go.sum
+++ b/go.sum
@@ -175,7 +175,6 @@ github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
-github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
We have found this approach very useful for most cases where processing messages one by one is too slow.